### PR TITLE
Issue targeted: #43

### DIFF
--- a/layout/columns2.php
+++ b/layout/columns2.php
@@ -127,4 +127,7 @@ if (!empty($footnote)) {
     // Add footnote layout file.
     require_once(__DIR__ . '/includes/footnote.php');
 }
+
+// Close the body and html and add JS.
+echo $OUTPUT->render_from_template('theme_boost_campus/closing', $templatecontext);
 // MODIFICATION END.

--- a/layout/login.php
+++ b/layout/login.php
@@ -33,7 +33,7 @@ $templatecontext = [
     'bodyattributes' => $bodyattributes
 ];
 
-echo $OUTPUT->render_from_template('theme_boost/login', $templatecontext);
+echo $OUTPUT->render_from_template('theme_boost_campus/login', $templatecontext);
 
 // MOFIFICATION START.
 // Include own layout file for the footnote region.
@@ -46,4 +46,7 @@ if (!empty($footnote)) {
     // Add footnote layout file.
     require_once(__DIR__ . '/includes/footnote.php');
 }
+
+// Close the body and html and add JS.
+echo $OUTPUT->render_from_template('theme_boost_campus/closinglogin', $templatecontext);
 // MODIFICATION END.

--- a/templates/closing.mustache
+++ b/templates/closing.mustache
@@ -1,0 +1,70 @@
+{{!
+    This file is part of Moodle - http://moodle.org/
+
+    Moodle is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Moodle is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+}}
+{{!
+    @template theme_boost_campus/closing
+
+    Admin time setting template.
+
+    Boost Campus 2 column layout template.
+
+    Context variables required for this template:
+    * sitename - The name of the site
+    * output - The core renderer for the page
+    * bodyattributes - attributes for the body tag as a string of html attributes
+    * sidepreblocks - HTML for the blocks
+    * hasblocks - true if there are blocks on this page
+    * navdraweropen - true if the nav drawer should be open on page load
+    * regionmainsettingsmenu - HTML for the region main settings menu
+    * hasregionmainsettingsmenu - There is a region main settings menu on this page.
+
+    Example context (json):
+    {
+        "sitename": "Moodle",
+        "output": {
+            "doctype": "<!DOCTYPE html>",
+            "page_title": "Test page",
+            "favicon": "favicon.ico",
+            "main_content": "<h1>Headings make html validators happier</h1>"
+         },
+        "bodyattributes":"",
+        "sidepreblocks": "<h2>Blocks html goes here</h2>",
+        "hasblocks":true,
+        "navdraweropen":true,
+        "regionmainsettingsmenu": "",
+        "hasregionmainsettingsmenu": false
+    }
+}}
+
+</body>
+</html>
+{{#js}}
+    require(['theme_boost/loader']);
+    require(['theme_boost/drawer'], function(mod) {
+    mod.init();
+    });
+    require(['theme_boost_campus/backtotop'], function(mod) {
+    mod.init();
+    });
+    require(['theme_boost_campus/catchshortcuts'], function(mod) {
+    mod.init({{{catchshortcuts}}});
+    });
+    {{#incoursesettings}}
+        require(['theme_boost_campus/incoursesettings'], function(mod) {
+        mod.init();
+        });
+    {{/incoursesettings}}
+{{/js}}

--- a/templates/closinglogin.mustache
+++ b/templates/closinglogin.mustache
@@ -1,0 +1,56 @@
+{{!
+    This file is part of Moodle - http://moodle.org/
+
+    Moodle is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Moodle is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+}}
+{{!
+    @template theme_boost_campus/closinglogin
+
+    Admin time setting template.
+
+    Boost Campus 2 column layout template.
+
+    Context variables required for this template:
+    * sitename - The name of the site
+    * output - The core renderer for the page
+    * bodyattributes - attributes for the body tag as a string of html attributes
+    * sidepreblocks - HTML for the blocks
+    * hasblocks - true if there are blocks on this page
+    * navdraweropen - true if the nav drawer should be open on page load
+    * regionmainsettingsmenu - HTML for the region main settings menu
+    * hasregionmainsettingsmenu - There is a region main settings menu on this page.
+
+    Example context (json):
+    {
+        "sitename": "Moodle",
+        "output": {
+            "doctype": "<!DOCTYPE html>",
+            "page_title": "Test page",
+            "favicon": "favicon.ico",
+            "main_content": "<h1>Headings make html validators happier</h1>"
+         },
+        "bodyattributes":"",
+        "sidepreblocks": "<h2>Blocks html goes here</h2>",
+        "hasblocks":true,
+        "navdraweropen":true,
+        "regionmainsettingsmenu": "",
+        "hasregionmainsettingsmenu": false
+    }
+}}
+
+</body>
+</html>
+{{#js}}
+require(['theme_boost/loader']);
+{{/js}}

--- a/templates/columns2.mustache
+++ b/templates/columns2.mustache
@@ -104,23 +104,3 @@
     </div>
     {{> theme_boost/nav-drawer }}
 </div>
-
-</body>
-</html>
-{{#js}}
-require(['theme_boost/loader']);
-require(['theme_boost/drawer'], function(mod) {
-    mod.init();
-});
-require(['theme_boost_campus/backtotop'], function(mod) {
-    mod.init();
-});
-require(['theme_boost_campus/catchshortcuts'], function(mod) {
-    mod.init({{{catchshortcuts}}});
-});
-{{#incoursesettings}}
-    require(['theme_boost_campus/incoursesettings'], function(mod) {
-    mod.init();
-    });
-{{/incoursesettings}}
-{{/js}}

--- a/templates/footer.mustache
+++ b/templates/footer.mustache
@@ -104,6 +104,7 @@
                 </nav>
                 {{{ output.standard_footer_html }}}
                 {{{ output.standard_end_of_body_html }}}
+            </div>
         </div>
     </div>
 </footer>

--- a/templates/login.mustache
+++ b/templates/login.mustache
@@ -1,0 +1,65 @@
+{{!
+    This file is part of Moodle - http://moodle.org/
+
+    Moodle is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Moodle is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+}}
+{{!
+    @template theme_boost/login
+
+    Login page template
+
+    Example context (json):
+    {
+        "output": {
+            "doctype": "<!DOCTYPE html>",
+            "page_title": "Login page",
+            "favicon": "favicon.ico",
+            "main_content": "<h1>Headers keep HTML validators happy</h1>"
+        }
+    }
+}}
+{{> theme_boost/head }}
+
+<body {{{ bodyattributes }}}>
+
+<div id="page-wrapper">
+
+    {{{ output.standard_top_of_body_html }}}
+
+    <div id="page" class="container-fluid mt-0">
+        <div id="page-content" class="row">
+            <div id="region-main-box" class="col-12">
+                <section id="region-main" class="col-12">
+                    {{{ output.course_content_header }}}
+                    {{{ output.main_content }}}
+                    {{{ output.course_content_footer }}}
+                </section>
+            </div>
+        </div>
+    </div>
+</div>
+<footer id="page-footer" class="py-3 bg-dark text-light">
+    <div class="container">
+        <div id="course-footer">{{{ output.course_footer }}}</div>
+
+        {{# output.page_doc_link }}
+            <p class="helplink">{{{ output.page_doc_link }}}</p>
+        {{/ output.page_doc_link }}
+
+        {{{ output.login_info }}}
+        {{{ output.home_link }}}
+        {{{ output.standard_footer_html }}}
+        {{{ output.standard_end_of_body_html }}}
+    </div>
+</footer>


### PR DESCRIPTION
Issue name: Body and HTML tags are closed before footer is output

Updated to theme/boost_campus/templates/ (5 files)
login.mustache | Copied in from Boost and removed closing HTML tags and JS
columns2.mustache | Removed closing HTML tags and JS area
closing.mustache | Added the closing tags body, html and add the JS
closinglogin.mustache | Added the closing tags body, html and add the JS
footer.mustache | Added Missing Div to Footer Area (Minor html fix)

Updated theme/boost_campus/layouts (2 files)
columns2.php | Call new closing template at bottom of the page.
login.php | Call new closing template at bottom of the page.