### PR TITLE
Fixed wrong id for timed info banner

### DIFF
--- a/templates/columns2.mustache
+++ b/templates/columns2.mustache
@@ -94,7 +94,7 @@
     <div id="page" class="container-fluid d-print-block">
 
         {{#timedinfobannershowonselectedpage}}
-        <div id="themeboostcampusitimedinfobanner" class="alert {{#timedibcss}}alert-{{{ timedibcss }}}{{/timedibcss}} mt-3" role="alert">
+        <div id="themeboostcampustimedinfobanner" class="alert {{#timedibcss}}alert-{{{ timedibcss }}}{{/timedibcss}} mt-3" role="alert">
           {{{ timedibcontent }}}
         </div>
         {{/timedinfobannershowonselectedpage}}


### PR DESCRIPTION
I just noticed a CSS rule was not working and this was the cause.