### PR TITLE
#109 - Example for easier settings inheritance (only an excerpt)

### DIFF
--- a/classes/consts/BoostCampusSettings.php
+++ b/classes/consts/BoostCampusSettings.php
@@ -25,6 +25,12 @@ use \context_system;
  */
 class BoostCampusSettings {
 
+    const THEME_NAME = "boost_campus";
+
+    const QUALIFIED_THEME_NAME = "theme_".self::THEME_NAME;
+
+    const RESET_CALLBACK = "theme_reset_all_caches";
+
     const SETTING_PRESET_HEADING = 'presetheading';
 
     const SETTING_PRESET = 'preset';
@@ -55,14 +61,19 @@ class BoostCampusSettings {
 
     const SETTING_BACK_TO_TOP_BUTTON = 'bcbttbutton';
 
+    public static function getQualifiedThemeName() {
+        return "theme_".static::THEME_NAME;
+    }
+
     public static function getPresetHeadingSetting() {
         $name = static::getSettingName(self::SETTING_PRESET_HEADING);
-        $title = get_string('presetheadingsetting', 'theme_boost_campus', null, true);
+        $title = get_string('presetheadingsetting', self::QUALIFIED_THEME_NAME, null, true);
         $setting = new admin_setting_heading($name, $title, null);
         return $setting;
     }
 
-    public static function getPresetSetting($themeName) {
+    public static function getPresetSetting() {
+        $fqThemeName = self::getQualifiedThemeName();
         $name = static::getSettingName(self::SETTING_PRESET);
         $title = get_string('preset', 'theme_boost', null, true);
         $description = get_string('preset_desc', 'theme_boost', null, true);
@@ -73,7 +84,7 @@ class BoostCampusSettings {
         $context = context_system::instance();
         $fs = get_file_storage();
 
-        $files = $fs->get_area_files($context->id, 'theme_'.$themeName, 'preset', 0, 'itemid, filepath, filename', false);
+        $files = $fs->get_area_files($context->id, $fqThemeName, 'preset', 0, 'itemid, filepath, filename', false);
 
         $choices = [];
         foreach ($files as $file) {
@@ -83,8 +94,8 @@ class BoostCampusSettings {
         $choices['default.scss'] = 'default.scss';
         $choices['plain.scss'] = 'plain.scss';
 
-        $setting = new admin_setting_configthemepreset($name, $title, $description, $default, $choices, $themeName);
-        $setting->set_updatedcallback('theme_reset_all_caches');
+        $setting = new admin_setting_configthemepreset($name, $title, $description, $default, $choices, $fqThemeName);
+        $setting->set_updatedcallback(self::RESET_CALLBACK);
         return $setting;
     }
 
@@ -100,7 +111,7 @@ class BoostCampusSettings {
 
     public static function getBrandColorHeadingSetting() {
         $name = static::getSettingName(self::SETTING_BRAND_COLOR_HEADING);
-        $title = get_string('brandcolorheadingsetting', 'theme_boost_campus', null, true);
+        $title = get_string('brandcolorheadingsetting', self::QUALIFIED_THEME_NAME, null, true);
         $setting = new admin_setting_heading($name, $title, null);
         return $setting;
     }
@@ -110,7 +121,7 @@ class BoostCampusSettings {
         $title = get_string('brandcolor', 'theme_boost', null, true);
         $description = get_string('brandcolor_desc', 'theme_boost', null, true);
         $setting = new admin_setting_configcolourpicker($name, $title, $description, '');
-        $setting->set_updatedcallback('theme_reset_all_caches');
+        $setting->set_updatedcallback(self::RESET_CALLBACK);
         return $setting;
     }
 
@@ -119,7 +130,7 @@ class BoostCampusSettings {
         $title = get_string('brandsuccesscolorsetting', 'theme_boost_campus', null, true);
         $description = get_string('brandsuccesscolorsetting_desc', 'theme_boost_campus', null, true);
         $setting = new admin_setting_configcolourpicker($name, $title, $description, '');
-        $setting->set_updatedcallback('theme_reset_all_caches');
+        $setting->set_updatedcallback(self::RESET_CALLBACK);
         return $setting;
     }
 
@@ -128,7 +139,7 @@ class BoostCampusSettings {
         $title = get_string('brandinfocolorsetting', 'theme_boost_campus', null, true);
         $description = get_string('brandinfocolorsetting_desc', 'theme_boost_campus', null, true);
         $setting = new admin_setting_configcolourpicker($name, $title, $description, '');
-        $setting->set_updatedcallback('theme_reset_all_caches');
+        $setting->set_updatedcallback(self::RESET_CALLBACK);
         return $setting;
     }
 
@@ -137,7 +148,7 @@ class BoostCampusSettings {
         $title = get_string('brandwarningcolorsetting', 'theme_boost_campus', null, true);
         $description = get_string('brandwarningcolorsetting_desc', 'theme_boost_campus', null, true);
         $setting = new admin_setting_configcolourpicker($name, $title, $description, '');
-        $setting->set_updatedcallback('theme_reset_all_caches');
+        $setting->set_updatedcallback(self::RESET_CALLBACK);
         return $setting;
     }
 
@@ -146,7 +157,7 @@ class BoostCampusSettings {
         $title = get_string('branddangercolorsetting', 'theme_boost_campus', null, true);
         $description = get_string('branddangercolorsetting_desc', 'theme_boost_campus', null, true);
         $setting = new admin_setting_configcolourpicker($name, $title, $description, '');
-        $setting->set_updatedcallback('theme_reset_all_caches');
+        $setting->set_updatedcallback(self::RESET_CALLBACK);
         return $setting;
     }
 
@@ -155,7 +166,7 @@ class BoostCampusSettings {
         $title = get_string('rawscsspre', 'theme_boost', null, true);
         $description = get_string('rawscsspre_desc', 'theme_boost', null, true);
         $setting = new admin_setting_scsscode($name, $title, $description, '', PARAM_RAW);
-        $setting->set_updatedcallback('theme_reset_all_caches');
+        $setting->set_updatedcallback(self::RESET_CALLBACK);
         return $setting;
     }
 
@@ -164,7 +175,7 @@ class BoostCampusSettings {
         $title = get_string('rawscss', 'theme_boost', null, true);
         $description = get_string('rawscss_desc', 'theme_boost', null, true);
         $setting = new admin_setting_scsscode($name, $title, $description, '', PARAM_RAW);
-        $setting->set_updatedcallback('theme_reset_all_caches');
+        $setting->set_updatedcallback(self::RESET_CALLBACK);
         return $setting;
     }
 
@@ -187,7 +198,7 @@ class BoostCampusSettings {
         ];
         $setting = new admin_setting_configselect($name, $title, $description, $addablockpositionsetting['positionblockregion'],
             $addablockpositionsetting);
-        $setting->set_updatedcallback('theme_reset_all_caches');
+        $setting->set_updatedcallback(self::RESET_CALLBACK);
         return $setting;
     }
 
@@ -207,10 +218,10 @@ class BoostCampusSettings {
     }
 
     protected static function getSettingValue(string $settingName) {
-        return get_config('theme_boost_campus', $settingName);
+        return get_config(self::getQualifiedThemeName(), $settingName);
     }
 
     protected static function getSettingName(string $setting) {
-        return 'theme_boost_campus'.'/'.$setting;
+        return self::getQualifiedThemeName().'/'.$setting;
     }
 }

--- a/classes/consts/BoostCampusSettings.php
+++ b/classes/consts/BoostCampusSettings.php
@@ -1,0 +1,216 @@
+<?php
+/**
+ * Author: Daniel Poggenpohl
+ * Date: 11.12.2020
+ */
+
+namespace theme_boost_campus\consts;
+
+defined('MOODLE_INTERNAL') || die();
+
+use \admin_setting_configcolourpicker;
+use \admin_setting_configthemepreset;
+use \admin_setting_configstoredfile;
+use \admin_setting_configselect;
+use \admin_setting_configcheckbox;
+use \admin_setting_scsscode;
+use \admin_setting_heading;
+
+use \context_system;
+
+/**
+ * Defines all Boost Campus settings which we use in our FeU child themes.
+ * Class BoostCampusSettings
+ * @package theme_boost_campus_feu_base\consts
+ */
+class BoostCampusSettings {
+
+    const SETTING_PRESET_HEADING = 'presetheading';
+
+    const SETTING_PRESET = 'preset';
+
+    const SETTING_PRESET_FILES = 'presetfiles';
+
+    const SETTING_BRAND_COLOR_HEADING = 'brandcolorheading';
+
+    const SETTING_BRAND_COLOR = 'brandcolor';
+
+    const SETTING_BRAND_COLOR_SUCCESS = 'brandsuccesscolor';
+
+    const SETTING_BRAND_COLOR_INFO = 'brandinfocolor';
+
+    const SETTING_BRAND_COLOR_WARNING = 'brandwarningcolor';
+
+    const SETTING_BRAND_COLOR_DANGER = 'branddangercolor';
+
+    const SETTING_SCSS_PRE = 'scsspre';
+
+    const SETTING_SCSS = 'scss';
+
+    const SETTING_ADD_BLOCK_WIDGET_HEADING = 'addablockwidgetheading';
+
+    const SETTING_ADD_BLOCK_WIDGET_POSITION = 'addablockposition';
+
+    const SETTING_BACK_TO_TOP_BUTTON_HEADING = 'bcbttbuttonheading';
+
+    const SETTING_BACK_TO_TOP_BUTTON = 'bcbttbutton';
+
+    public static function getPresetHeadingSetting() {
+        $name = static::getSettingName(self::SETTING_PRESET_HEADING);
+        $title = get_string('presetheadingsetting', 'theme_boost_campus', null, true);
+        $setting = new admin_setting_heading($name, $title, null);
+        return $setting;
+    }
+
+    public static function getPresetSetting($themeName) {
+        $name = static::getSettingName(self::SETTING_PRESET);
+        $title = get_string('preset', 'theme_boost', null, true);
+        $description = get_string('preset_desc', 'theme_boost', null, true);
+        $default = 'default.scss';
+
+        // We list files in our own file area to add to the drop down. We will provide our own function to
+        // load all the presets from the correct paths.
+        $context = context_system::instance();
+        $fs = get_file_storage();
+
+        $files = $fs->get_area_files($context->id, 'theme_'.$themeName, 'preset', 0, 'itemid, filepath, filename', false);
+
+        $choices = [];
+        foreach ($files as $file) {
+            $choices[$file->get_filename()] = $file->get_filename();
+        }
+        // These are the built in presets from Boost.
+        $choices['default.scss'] = 'default.scss';
+        $choices['plain.scss'] = 'plain.scss';
+
+        $setting = new admin_setting_configthemepreset($name, $title, $description, $default, $choices, $themeName);
+        $setting->set_updatedcallback('theme_reset_all_caches');
+        return $setting;
+    }
+
+    public static function getPresetFilesSetting() {
+        $name = static::getSettingName(self::SETTING_PRESET_FILES);
+        $title = get_string('presetfiles', 'theme_boost', null, true);
+        $description = get_string('presetfiles_desc', 'theme_boost', null, true);
+
+        $setting = new admin_setting_configstoredfile($name, $title, $description, 'preset', 0,
+            array('maxfiles' => 20, 'accepted_types' => array('.scss')));
+        return $setting;
+    }
+
+    public static function getBrandColorHeadingSetting() {
+        $name = static::getSettingName(self::SETTING_BRAND_COLOR_HEADING);
+        $title = get_string('brandcolorheadingsetting', 'theme_boost_campus', null, true);
+        $setting = new admin_setting_heading($name, $title, null);
+        return $setting;
+    }
+
+    public static function getBrandColorSetting() {
+        $name = static::getSettingName(self::SETTING_BRAND_COLOR);
+        $title = get_string('brandcolor', 'theme_boost', null, true);
+        $description = get_string('brandcolor_desc', 'theme_boost', null, true);
+        $setting = new admin_setting_configcolourpicker($name, $title, $description, '');
+        $setting->set_updatedcallback('theme_reset_all_caches');
+        return $setting;
+    }
+
+    public static function getBrandColorSuccessSetting() {
+        $name = static::getSettingName(self::SETTING_BRAND_COLOR_SUCCESS);
+        $title = get_string('brandsuccesscolorsetting', 'theme_boost_campus', null, true);
+        $description = get_string('brandsuccesscolorsetting_desc', 'theme_boost_campus', null, true);
+        $setting = new admin_setting_configcolourpicker($name, $title, $description, '');
+        $setting->set_updatedcallback('theme_reset_all_caches');
+        return $setting;
+    }
+
+    public static function getBrandColorInfoSetting() {
+        $name = static::getSettingName(self::SETTING_BRAND_COLOR_INFO);
+        $title = get_string('brandinfocolorsetting', 'theme_boost_campus', null, true);
+        $description = get_string('brandinfocolorsetting_desc', 'theme_boost_campus', null, true);
+        $setting = new admin_setting_configcolourpicker($name, $title, $description, '');
+        $setting->set_updatedcallback('theme_reset_all_caches');
+        return $setting;
+    }
+
+    public static function getBrandColorWarningSetting() {
+        $name = static::getSettingName(self::SETTING_BRAND_COLOR_WARNING);
+        $title = get_string('brandwarningcolorsetting', 'theme_boost_campus', null, true);
+        $description = get_string('brandwarningcolorsetting_desc', 'theme_boost_campus', null, true);
+        $setting = new admin_setting_configcolourpicker($name, $title, $description, '');
+        $setting->set_updatedcallback('theme_reset_all_caches');
+        return $setting;
+    }
+
+    public static function getBrandColorDangerSetting() {
+        $name = static::getSettingName(self::SETTING_BRAND_COLOR_DANGER);
+        $title = get_string('branddangercolorsetting', 'theme_boost_campus', null, true);
+        $description = get_string('branddangercolorsetting_desc', 'theme_boost_campus', null, true);
+        $setting = new admin_setting_configcolourpicker($name, $title, $description, '');
+        $setting->set_updatedcallback('theme_reset_all_caches');
+        return $setting;
+    }
+
+    public static function getScssPreSetting() {
+        $name = static::getSettingName(self::SETTING_SCSS_PRE);
+        $title = get_string('rawscsspre', 'theme_boost', null, true);
+        $description = get_string('rawscsspre_desc', 'theme_boost', null, true);
+        $setting = new admin_setting_scsscode($name, $title, $description, '', PARAM_RAW);
+        $setting->set_updatedcallback('theme_reset_all_caches');
+        return $setting;
+    }
+
+    public static function getScssSetting() {
+        $name = static::getSettingName(self::SETTING_SCSS);
+        $title = get_string('rawscss', 'theme_boost', null, true);
+        $description = get_string('rawscss_desc', 'theme_boost', null, true);
+        $setting = new admin_setting_scsscode($name, $title, $description, '', PARAM_RAW);
+        $setting->set_updatedcallback('theme_reset_all_caches');
+        return $setting;
+    }
+
+    public static function getAddBlockWidgetHeadingSetting() {
+        $name = static::getSettingName(self::SETTING_ADD_BLOCK_WIDGET_HEADING);
+        $title = get_string('addablockwidgetheadingsetting', 'theme_boost_campus', null, true);
+        $setting = new admin_setting_heading($name, $title, null);
+        return $setting;
+    }
+
+    public static function getAddBlockWidgetSetting() {
+        $name = static::getSettingName(self::SETTING_ADD_BLOCK_WIDGET_POSITION);
+        $title = get_string('addablockpositionsetting', 'theme_boost_campus', null, true);
+        $description = get_string('addablockpositionsetting_desc', 'theme_boost_campus', null, true);
+        $addablockpositionsetting = [
+            // Don't use string lazy loading (= false) because the string will be directly used and would produce a
+            // PHP warning otherwise.
+            'positionblockregion' => get_string('settingsaddablockpositionbottomblockregion', 'theme_boost_campus', null, false),
+            'positionnavdrawer' => get_string('settingsaddablockpositionbottomnavdrawer', 'theme_boost_campus', null, true),
+        ];
+        $setting = new admin_setting_configselect($name, $title, $description, $addablockpositionsetting['positionblockregion'],
+            $addablockpositionsetting);
+        $setting->set_updatedcallback('theme_reset_all_caches');
+        return $setting;
+    }
+
+    public static function getBackToTopHeadingSetting() {
+        $name = static::getSettingName(self::SETTING_BACK_TO_TOP_BUTTON_HEADING);
+        $title = get_string('bcbttbuttonheadingsetting', 'theme_boost_campus', null, true);
+        $setting = new admin_setting_heading($name, $title, null);
+        return $setting;
+    }
+
+    public static function getBackToTopButtonSetting() {
+        $name = static::getSettingName(self::SETTING_BACK_TO_TOP_BUTTON);
+        $title = get_string('bcbttbuttonsetting', 'theme_boost_campus', null, true);
+        $description = get_string('bcbttbuttonsetting_desc', 'theme_boost_campus', null, true);
+        $setting = new admin_setting_configcheckbox($name, $title, $description, 0);
+        return $setting;
+    }
+
+    protected static function getSettingValue(string $settingName) {
+        return get_config('theme_boost_campus', $settingName);
+    }
+
+    protected static function getSettingName(string $setting) {
+        return 'theme_boost_campus'.'/'.$setting;
+    }
+}

--- a/settings.php
+++ b/settings.php
@@ -24,62 +24,32 @@
 
 defined('MOODLE_INTERNAL') || die();
 
+use theme_boost_campus\consts\BoostCampusSettings;
+
 if ($ADMIN->fulltree) {
 
     // Create settings page with tabs.
     $settings = new theme_boost_admin_settingspage_tabs('themesettingboost_campus',
         get_string('configtitle', 'theme_boost_campus', null, true));
 
-
     // Create general tab.
-    $page = new admin_settingpage('theme_boost_campus_general', get_string('generalsettings', 'theme_boost', null, true));
+    $generalTab = new admin_settingpage('theme_boost_campus_general', get_string('generalsettings', 'theme_boost', null, true));
 
     // Settings title to group preset related settings together with a common heading. We don't want a description here.
-    $name = 'theme_boost_campus/presetheading';
-    $title = get_string('presetheadingsetting', 'theme_boost_campus', null, true);
-    $setting = new admin_setting_heading($name, $title, null);
-    $page->add($setting);
+    $generalTab->add(BoostCampusSettings::getPresetHeadingSetting());
 
     // Replicate the preset setting from theme_boost.
-    $name = 'theme_boost_campus/preset';
-    $title = get_string('preset', 'theme_boost', null, true);
-    $description = get_string('preset_desc', 'theme_boost', null, true);
-    $default = 'default.scss';
-
-    // We list files in our own file area to add to the drop down. We will provide our own function to
-    // load all the presets from the correct paths.
-    $context = context_system::instance();
-    $fs = get_file_storage();
-    $files = $fs->get_area_files($context->id, 'theme_boost_campus', 'preset', 0, 'itemid, filepath, filename', false);
-
-    $choices = [];
-    foreach ($files as $file) {
-        $choices[$file->get_filename()] = $file->get_filename();
-    }
-    // These are the built in presets from Boost.
-    $choices['default.scss'] = 'default.scss';
-    $choices['plain.scss'] = 'plain.scss';
-
-    $setting = new admin_setting_configthemepreset($name, $title, $description, $default, $choices, 'boost_campus');
-    $setting->set_updatedcallback('theme_reset_all_caches');
-    $page->add($setting);
-
+    $generalTab->add(BoostCampusSettings::getPresetSetting('theme_boost_campus'));
 
     // Preset files setting.
-    $name = 'theme_boost_campus/presetfiles';
-    $title = get_string('presetfiles', 'theme_boost', null, true);
-    $description = get_string('presetfiles_desc', 'theme_boost', null, true);
-
-    $setting = new admin_setting_configstoredfile($name, $title, $description, 'preset', 0,
-        array('maxfiles' => 20, 'accepted_types' => array('.scss')));
-    $page->add($setting);
+    $generalTab->add(BoostCampusSettings::getPresetFilesSetting());
 
     // Settings title to group core background image related settings together with a common heading.
     // We don't want a description here.
     $name = 'theme_boost_campus/backgroundimageheading';
     $title = get_string('backgroundimage', 'theme_boost', null, true);
     $setting = new admin_setting_heading($name, $title, null);
-    $page->add($setting);
+    $generalTab->add($setting);
 
     // Background image setting.
     $name = 'theme_boost_campus/backgroundimage';
@@ -88,60 +58,32 @@ if ($ADMIN->fulltree) {
     $description .= get_string('backgroundimage_desc_note', 'theme_boost_campus', null, true);
     $setting = new admin_setting_configstoredfile($name, $title, $description, 'backgroundimage');
     $setting->set_updatedcallback('theme_reset_all_caches');
-    $page->add($setting);
+    $generalTab->add($setting);
 
     // Settings title to group brand color related settings together with a common heading. We don't want a description here.
-    $name = 'theme_boost_campus/brandcolorheading';
-    $title = get_string('brandcolorheadingsetting', 'theme_boost_campus', null, true);
-    $setting = new admin_setting_heading($name, $title, null);
-    $page->add($setting);
+    $generalTab->add(BoostCampusSettings::getBrandColorHeadingSetting());
 
     // Variable $primary.
     // We use an empty default value because the default colour should come from the preset.
-    $name = 'theme_boost_campus/brandcolor';
-    $title = get_string('brandcolor', 'theme_boost', null, true);
-    $description = get_string('brandcolor_desc', 'theme_boost', null, true);
-    $setting = new admin_setting_configcolourpicker($name, $title, $description, '');
-    $setting->set_updatedcallback('theme_reset_all_caches');
-    $page->add($setting);
+    $generalTab->add(BoostCampusSettings::getBrandColorSetting());
 
     // Variable $success.
-    $name = 'theme_boost_campus/brandsuccesscolor';
-    $title = get_string('brandsuccesscolorsetting', 'theme_boost_campus', null, true);
-    $description = get_string('brandsuccesscolorsetting_desc', 'theme_boost_campus', null, true);
-    $setting = new admin_setting_configcolourpicker($name, $title, $description, '');
-    $setting->set_updatedcallback('theme_reset_all_caches');
-    $page->add($setting);
+    $generalTab->add(BoostCampusSettings::getBrandColorSuccessSetting());
 
     // Variable $info.
-    $name = 'theme_boost_campus/brandinfocolor';
-    $title = get_string('brandinfocolorsetting', 'theme_boost_campus', null, true);
-    $description = get_string('brandinfocolorsetting_desc', 'theme_boost_campus', null, true);
-    $setting = new admin_setting_configcolourpicker($name, $title, $description, '');
-    $setting->set_updatedcallback('theme_reset_all_caches');
-    $page->add($setting);
+    $generalTab->add(BoostCampusSettings::getBrandColorInfoSetting());
 
     // Variable $warning.
-    $name = 'theme_boost_campus/brandwarningcolor';
-    $title = get_string('brandwarningcolorsetting', 'theme_boost_campus', null, true);
-    $description = get_string('brandwarningcolorsetting_desc', 'theme_boost_campus', null, true);
-    $setting = new admin_setting_configcolourpicker($name, $title, $description, '');
-    $setting->set_updatedcallback('theme_reset_all_caches');
-    $page->add($setting);
+    $generalTab->add(BoostCampusSettings::getBrandColorWarningSetting());
 
     // Variable $danger.
-    $name = 'theme_boost_campus/branddangercolor';
-    $title = get_string('branddangercolorsetting', 'theme_boost_campus', null, true);
-    $description = get_string('branddangercolorsetting_desc', 'theme_boost_campus', null, true);
-    $setting = new admin_setting_configcolourpicker($name, $title, $description, '');
-    $setting->set_updatedcallback('theme_reset_all_caches');
-    $page->add($setting);
+    $generalTab->add(BoostCampusSettings::getBrandColorDangerSetting());
 
     // Settings title to group favicon related settings together with a common heading. We don't want a description here.
     $name = 'theme_boost_campus/faviconheading';
     $title = get_string('faviconheadingsetting', 'theme_boost_campus', null, true);
     $setting = new admin_setting_heading($name, $title, null);
-    $page->add($setting);
+    $generalTab->add($setting);
 
     // Favicon upload.
     $name = 'theme_boost_campus/favicon';
@@ -150,37 +92,27 @@ if ($ADMIN->fulltree) {
     $setting = new admin_setting_configstoredfile($name, $title, $description, 'favicon', 0,
         array('maxfiles' => 1, 'accepted_types' => array('.ico', '.png')));
     $setting->set_updatedcallback('theme_reset_all_caches');
-    $page->add($setting);
+    $generalTab->add($setting);
 
     // Add tab to settings page.
-    $settings->add($page);
+    $settings->add($generalTab);
 
 
     // Create advanced settings tab.
-    $page = new admin_settingpage('theme_boost_campus_advanced', get_string('advancedsettings', 'theme_boost', null, true));
+    $advancedTab = new admin_settingpage('theme_boost_campus_advanced', get_string('advancedsettings', 'theme_boost', null, true));
 
     // Raw SCSS to include before the content.
-    $name = 'theme_boost_campus/scsspre';
-    $title = get_string('rawscsspre', 'theme_boost', null, true);
-    $description = get_string('rawscsspre_desc', 'theme_boost', null, true);
-    $setting = new admin_setting_scsscode($name, $title, $description, '', PARAM_RAW);
-    $setting->set_updatedcallback('theme_reset_all_caches');
-    $page->add($setting);
+    $advancedTab->add(BoostCampusSettings::getScssPreSetting());
 
     // Raw SCSS to include after the content.
-    $name = 'theme_boost_campus/scss';
-    $title = get_string('rawscss', 'theme_boost', null, true);
-    $description = get_string('rawscss_desc', 'theme_boost', null, true);
-    $setting = new admin_setting_scsscode($name, $title, $description, '', PARAM_RAW);
-    $setting->set_updatedcallback('theme_reset_all_caches');
-    $page->add($setting);
+    $advancedTab->add(BoostCampusSettings::getScssSetting());
 
     // Settings title for the catching keybaord commands.
     $name = 'theme_boost_campus/catchkeyboardcommandsheading';
     $title = get_string('catchkeyboardcommandsheadingsetting', 'theme_boost_campus', null, true);
     $description = get_string('catchkeyboardcommandsheadingsetting_desc', 'theme_boost_campus', null, true);
     $setting = new admin_setting_heading($name, $title, $description);
-    $page->add($setting);
+    $advancedTab->add($setting);
 
     // Setting for catching the end key.
     $name = 'theme_boost_campus/catchendkey';
@@ -188,7 +120,7 @@ if ($ADMIN->fulltree) {
     $description = get_string('catchendkeysetting_desc', 'theme_boost_campus', null, true) . ' ' .
         get_string('catchkeys_desc_addition', 'theme_boost_campus', null, true);
     $setting = new admin_setting_configcheckbox($name, $title, $description, 0);
-    $page->add($setting);
+    $advancedTab->add($setting);
 
     // Setting for catching the cmd + arrow down keys.
     $name = 'theme_boost_campus/catchcmdarrowdown';
@@ -196,7 +128,7 @@ if ($ADMIN->fulltree) {
     $description = get_string('catchcmdarrowdownsetting_desc', 'theme_boost_campus', null, true) . ' ' .
         get_string('catchkeys_desc_addition', 'theme_boost_campus', null, true);
     $setting = new admin_setting_configcheckbox($name, $title, $description, 0);
-    $page->add($setting);
+    $advancedTab->add($setting);
 
     // Setting for catching the strg + arrow down keys.
     $name = 'theme_boost_campus/catchctrlarrowdown';
@@ -204,43 +136,22 @@ if ($ADMIN->fulltree) {
     $description = get_string('catchctrlarrowdownsetting_desc', 'theme_boost_campus', null, true) . ' ' .
         get_string('catchkeys_desc_addition', 'theme_boost_campus', null, true);
     $setting = new admin_setting_configcheckbox($name, $title, $description, 0);
-    $page->add($setting);
+    $advancedTab->add($setting);
 
     // Settings title for the Add a block widget. We don't need a description here.
-    $name = 'theme_boost_campus/addablockwidgetheading';
-    $title = get_string('addablockwidgetheadingsetting', 'theme_boost_campus', null, true);
-    $setting = new admin_setting_heading($name, $title, null);
-    $page->add($setting);
+    $advancedTab->add(BoostCampusSettings::getAddBlockWidgetHeadingSetting());
+
     // Setting to manage where the Add a block widget should be displayed.
-    $name = 'theme_boost_campus/addablockposition';
-    $title = get_string('addablockpositionsetting', 'theme_boost_campus', null, true);
-    $description = get_string('addablockpositionsetting_desc', 'theme_boost_campus', null, true);
-    $addablockpositionsetting = [
-        // Don't use string lazy loading (= false) because the string will be directly used and would produce a
-        // PHP warning otherwise.
-        'positionblockregion' => get_string('settingsaddablockpositionbottomblockregion', 'theme_boost_campus', null, false),
-        'positionnavdrawer' => get_string('settingsaddablockpositionbottomnavdrawer', 'theme_boost_campus', null, true),
-    ];
-    $setting = new admin_setting_configselect($name, $title, $description, $addablockpositionsetting['positionblockregion'],
-        $addablockpositionsetting);
-    $setting->set_updatedcallback('theme_reset_all_caches');
-    $page->add($setting);
+    $advancedTab->add(BoostCampusSettings::getAddBlockWidgetSetting());
 
     // Settings title for "Back to top" button. We don't need a description here.
-    $name = 'theme_boost_campus/bcbttbuttonheading';
-    $title = get_string('bcbttbuttonheadingsetting', 'theme_boost_campus', null, true);
-    $setting = new admin_setting_heading($name, $title, null);
-    $page->add($setting);
+    $advancedTab->add(BoostCampusSettings::getBackToTopHeadingSetting());
 
     // Setting enabling the Boost Campus version of the "Back to top" button.
-    $name = 'theme_boost_campus/bcbttbutton';
-    $title = get_string('bcbttbuttonsetting', 'theme_boost_campus', null, true);
-    $description = get_string('bcbttbuttonsetting_desc', 'theme_boost_campus', null, true);
-    $setting = new admin_setting_configcheckbox($name, $title, $description, 0);
-    $page->add($setting);
+    $advancedTab->add(BoostCampusSettings::getBackToTopButtonSetting());
 
     // Add tab to settings page.
-    $settings->add($page);
+    $settings->add($advancedTab);
 
 
     // Create course layout settings tab.


### PR DESCRIPTION
- Example for a Settings class that allows inheritance by changing only a few things (of course it can be improved)
- use those Settings in the settings.php

Basically, one could add every setting to the class and abstract away any theme references.
With a little more work (and probably a little less "static") one could extend that Settings class by probably only changing the theme name, if they want.