### PR TITLE
Profile button with "editadvanced" link for users with capability 'moodle/user:update'

### DIFF
--- a/classes/output/core_renderer.php
+++ b/classes/output/core_renderer.php
@@ -168,7 +168,7 @@ class core_renderer extends \core_renderer {
             $userid = optional_param('id', $USER->id, PARAM_INT);
             // Check if the shown and the operating user are identical.
             $currentuser = $USER->id == $userid;
-            if (($currentuser || is_siteadmin($USER) || !is_siteadmin($user)) &&
+            if (($currentuser || is_siteadmin($USER) || !is_siteadmin($userid)) &&
                 has_capability('moodle/user:update', \context_system::instance())) {
                 $url = new moodle_url('/user/editadvanced.php', array('id'       => $userid, 'course' => $COURSE->id,
                                                                       'returnto' => 'profile'));

--- a/classes/output/core_renderer.php
+++ b/classes/output/core_renderer.php
@@ -168,7 +168,7 @@ class core_renderer extends \core_renderer {
             $userid = optional_param('id', $USER->id, PARAM_INT);
             // Check if the shown and the operating user are identical.
             $currentuser = $USER->id == $userid;
-            if (($currentuser || is_siteadmin($USER)) &&
+            if (($currentuser || is_siteadmin($USER) || !is_siteadmin($user)) &&
                 has_capability('moodle/user:update', \context_system::instance())) {
                 $url = new moodle_url('/user/editadvanced.php', array('id'       => $userid, 'course' => $COURSE->id,
                                                                       'returnto' => 'profile'));


### PR DESCRIPTION
Be consistent with function core_myprofile_navigation() in lib/myprofilelib.php:
Users with the capability 'moodle/user:update' shall be able to go to "user/editadvanced.php" when editing a non-admin user.